### PR TITLE
refactor: use type-only import for `SvelteComponentTyped` interface

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -53,7 +53,7 @@ export const templateSvelte = (
 export const templateTs = (
   moduleName: string
 ) => `/// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ${moduleName}Props
   extends svelte.JSX.SVGAttributes<SVGSVGElement> {}

--- a/tests/__snapshots__/template.test.ts.snap
+++ b/tests/__snapshots__/template.test.ts.snap
@@ -8,7 +8,7 @@ exports[`templateSvelte 3`] = `"<svg class:my-class={true} id=\\"id\\" class:cla
 
 exports[`templateTs 1`] = `
 "/// <reference types=\\"svelte\\" />
-import { SvelteComponentTyped } from \\"svelte\\";
+import type { SvelteComponentTyped } from \\"svelte\\";
 
 export interface IconNameProps
   extends svelte.JSX.SVGAttributes<SVGSVGElement> {}


### PR DESCRIPTION
**Refactor**

- use type-only import for `SvelteComponentTyped` in generated TypeScript definition