### PR TITLE
fix!: revert back to using `SvelteComponentTyped` for Svelte 3 compatibility

### DIFF
--- a/src/create-library.ts
+++ b/src/create-library.ts
@@ -133,10 +133,10 @@ export async function createLibrary(
 
     const uniqueModuleNames = [...new Set(moduleNames)];
     const index = createIndexFile(uniqueModuleNames);
-    const indexTypes = `import type { SvelteComponent } from "svelte";
+    const indexTypes = `import type { SvelteComponentTyped } from "svelte";
 import type { SVGAttributes } from "svelte/elements";
 
-declare class SvgComponent extends SvelteComponent<
+declare class SvgComponent extends SvelteComponentTyped<
   SVGAttributes<SVGSVGElement> & {
     // Support data-* attributes in Svelte 3
     [key: \`data-\${string}\`]: any;


### PR DESCRIPTION
`SvelteComponent` will produce an error `SvelteComponentDev is not generic` when used with Svelte 3.

Using `SvelteComponentTyped` is the only way to support both 3 and 4.

The actual error with the previous types stemmed from the `events` parameter being stricter (`{}` does not match `Record<string, any>` with TypeScript strict mode enabled).